### PR TITLE
feat(webgl): add premultiplied alpha option

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ OPENSEADRAGON CHANGELOG
     * CacheRecord supports 'internal cache' of 'SimpleCache' type. This cache can be used by drawers to hide complex types used for rendering. Such caches are stored internally on CacheRecord objects.
     * CacheRecord drives asynchronous data management and ensures correct behavior through awaiting Promises.
     * TileCache adds new methods for cache modification: renameCache, cloneCache, injectCache, replaceCache, restoreTilesThatShareOriginalCache, safeUnloadCache, unloadCacheForTile and more. Used internally within invalidation events
+* Added: WebGLDrawer option to unpack textures with premultiplied alpha.
     * Tiles have up to two 'originalCacheKey' and 'cacheKey' caches, which keep original data and target drawn data (if modified).
     * Invalidation Pipeline: New event 'tile-invalidated' and requestInvalidate methods on World and TiledImage. Tiles get methods to modify data to draw, system prepares data for drawing and swaps them with the current main tile cache.
     * New test suites for the new cache system, conversion pipeline and invalidation events.

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -768,18 +768,25 @@
   *
   */
 
- /**
-  * @typedef {Object.<string, Object>} DrawerOptions - give the renderer options (both shared - BaseDrawerOptions, and custom).
-  *   Supports arbitrary keys: you can register any drawer on the OpenSeadragon namespace, it will get automatically recognized
-  *   and its getType() implementation will define what key to specify the options with.
-  * @memberof OpenSeadragon
-  * @property {BaseDrawerOptions} [webgl] - options if the WebGLDrawer is used.
-  * @property {BaseDrawerOptions} [canvas] - options if the CanvasDrawer is used.
-  * @property {BaseDrawerOptions} [html] - options if the HTMLDrawer is used.
-  * @property {BaseDrawerOptions} [custom] - options if a custom drawer is used.
-  *
-  * //Note: if you want to add change options for target drawer change type to {BaseDrawerOptions & MyDrawerOpts}
-  */
+/**
+ * @typedef {BaseDrawerOptions} WebGLDrawerOptions
+ * @memberof OpenSeadragon
+ * @property {Boolean} [unpackWithPremultipliedAlpha=false]
+ *  Whether to enable gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL when uploading textures.
+ */
+
+/**
+ * @typedef {Object.<string, Object>} DrawerOptions - give the renderer options (both shared - BaseDrawerOptions, and custom).
+ *   Supports arbitrary keys: you can register any drawer on the OpenSeadragon namespace, it will get automatically recognized
+ *   and its getType() implementation will define what key to specify the options with.
+ * @memberof OpenSeadragon
+ * @property {WebGLDrawerOptions} [webgl] - options if the WebGLDrawer is used.
+ * @property {BaseDrawerOptions} [canvas] - options if the CanvasDrawer is used.
+ * @property {BaseDrawerOptions} [html] - options if the HTMLDrawer is used.
+ * @property {BaseDrawerOptions} [custom] - options if a custom drawer is used.
+ *
+ * //Note: if you want to add change options for target drawer change type to {BaseDrawerOptions & MyDrawerOpts}
+ */
 
 
 /**
@@ -1403,7 +1410,7 @@ function OpenSeadragon( options ){
 
             drawerOptions: {
                 webgl: {
-
+                    unpackWithPremultipliedAlpha: false,
                 },
                 canvas: {
 


### PR DESCRIPTION
Summary

- Introduced a new unpackWithPremultipliedAlpha option and setter for the WebGL drawer, enabling or disabling premultiplied alpha during texture unpacking
- Ensured the WebGL context respects the new option by configuring the pixel store both at setup and when uploading textures
- Documented the WebGL-specific option within global drawer settings and assigned a default value in the viewer configuration
- Logged the addition in the changelog for upcoming release notes